### PR TITLE
fix: correct vercel runtime mapping

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,12 +1,6 @@
 {
   "functions": {
-    "api/api.php": {
-      "runtime": "vercel-php@0.7.0"
-    },
-    "api/auth.php": {
-      "runtime": "vercel-php@0.7.0"
-    },
-    "api/users_api.php": {
+    "api/*.php": {
       "runtime": "vercel-php@0.7.0"
     }
   },


### PR DESCRIPTION
## Summary
- ensure all PHP API endpoints use `vercel-php` runtime via glob pattern

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689907456e14832ca32dcb9d4b25acc9